### PR TITLE
Added ability to set the filename for the downloaded file. 

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,6 @@ Options:
 
 separator (Default: ',')
 The character that separates entries in the resulting CSV file.
-
  
 
 delivery (Default: 'popup')
@@ -41,6 +40,7 @@ An array containing strings of the column headers
 
 Example: [code] jQuery('#table-id').TableCSVExport({header:['Name','Mon','Tue','Wed','Thr','Fri']}) [/code]
 
+
 columns (Default: [])
 
 An array containing strings consisting of the headers for the columns to export. This MUST be a subset of the array passed to the header option.
@@ -53,19 +53,37 @@ This will export only the 'Name' and 'Mon' columns as CSV data.
 
 When using the columns option to only export certain columns, you must also set the header array and the columns array must be a subset of the header array.
 
+
 emptyValue (Default: '')
 
 Column default value if the column is empty.
 
+
 showHiddenRows (Default: false)
 
 if it's true, will export rows with display: 'none'.
+
 
 rowFilter (Default: '')
 
 You can add jquery selector filter, to filter table rows.
 
 Ex: rowFilter: '.myClass'
+
+
+filename (Default: 'download.csv')
+
+Choose what the downloaded filename will be when using the 'download' delivery. Currently only reliable in Chrome.
+
+Example usage on a download button:
+$('#download-btn').click(function (e) {
+    e.preventDefault();
+    $('#my-table').TableCSVExport({
+        delivery: 'download',
+        filename: 'device-usage.csv'
+    });
+});
+
 
 Important Notes:
  

--- a/jquery.TableCSVExport.js
+++ b/jquery.TableCSVExport.js
@@ -20,7 +20,8 @@ jQuery.fn.TableCSVExport = function (options) {
         delivery: 'popup' /* popup, value, download */,
         emptyValue: '',
         showHiddenRows: false,
-        rowFilter: ""
+        rowFilter: "",
+        filename: "download.csv"
     },
     options);
 
@@ -154,7 +155,12 @@ jQuery.fn.TableCSVExport = function (options) {
     }
     function popup(data) {
         if (options.delivery == 'download') {
-            window.location = 'data:text/csv;charset=utf8,' + encodeURIComponent(data);
+            var aLink = document.createElement('a');
+            var evt = document.createEvent("HTMLEvents");
+            evt.initEvent("click");
+            aLink.download = options.filename;
+            aLink.href = 'data:text/csv;charset=utf8,' + encodeURIComponent(data);
+            aLink.dispatchEvent(evt);
             return true;
         } else {
             var generator = window.open('', 'csv', 'height=400,width=600');


### PR DESCRIPTION
Hey thanks for the plugin. I edited it very slightly so that I could set the download filename instead of it defaulting to "download". Only works in Chrome at the moment, but it shouldn't break in other browsers.