### PR TITLE
Add useTHead option to adjust header, row and cell lookups

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,12 @@ The manner in which to return the CSV data file. Options are:
 'download' - triggers a download of a file containing the CSV data
  
 
+useTHead (Default: false)
+
+By default column headers are found by looking for th elements within the table.
+
+If useTHead is true the header and row lookup is changed. Column headers are found by looking for th's and td's within a thead element. Cell content is found by looking for th's and td's within a tbody element.
+
 header (Default: [])
 
 An array containing strings of the column headers

--- a/jquery.TableCSVExport.js
+++ b/jquery.TableCSVExport.js
@@ -20,8 +20,9 @@ jQuery.fn.TableCSVExport = function (options) {
         delivery: 'popup' /* popup, value, download */,
         emptyValue: '',
         showHiddenRows: false,
-	    rowFilter: "",
-	    filename: "download.csv"
+        rowFilter: "",
+        filename: "download.csv",
+        useTHead: false
     },
     options);
 
@@ -61,7 +62,7 @@ jQuery.fn.TableCSVExport = function (options) {
             }
         }
     } else {
-        getAvailableElements(el).find('th').each(function () {
+        getAvailableElements(el).find(options.useTHead ? 'thead th, thead td' : 'th').each(function () {
             if (jQuery(this).css('display') != 'none' || options.showHiddenRows) tmpRow[tmpRow.length] = formatData(jQuery(this).html());
         });
     }
@@ -74,7 +75,7 @@ jQuery.fn.TableCSVExport = function (options) {
         getAvailableRows(el).each(function () {
             var tmpRow = [];
             var extraDataCounter = 0;
-            getAvailableElements(this).find('td').each(function () {
+            getAvailableElements(this).find(options.useTHead ? 'th, td' : 'td').each(function () {
                 if (extraDataCounter == insertBeforeNum) {
                     tmpRow[tmpRow.length] = jQuery.trim(options.extraData[trCounter - 1]);
                 }
@@ -96,7 +97,7 @@ jQuery.fn.TableCSVExport = function (options) {
             var tmpRow = [];
             var columnCounter = 0;
             var extraDataCounter = 0;
-            getAvailableElements(this).find('td').each(function () {
+            getAvailableElements(this).find(options.useTHead ? 'th, td' : 'td').each(function () {
                 if ((columnCounter in columnNumbers) && (extraDataCounter == insertBeforeNum)) {
                     tmpRow[tmpRow.length] = jQuery.trim(formatData(options.extraData[trCounter - 1]));
                 }
@@ -112,7 +113,7 @@ jQuery.fn.TableCSVExport = function (options) {
     }
 
     function getAvailableRows(el) {
-        return jQuery(el).find('tr' + options.rowFilter);
+        return jQuery(el).find((options.useTHead ? 'tbody tr' : 'tr') + options.rowFilter);
     }
 
     function getAvailableElements(el) {


### PR DESCRIPTION
I've added an option which adjusts how column header and cell content lookups are made. If useTHead is true columns headers will be retrieved from th and td's within the thead element and cell contents will be retrieved from th and td's within the tbody element. Existing behaviour is unchanged if this option is not set.